### PR TITLE
Add llvm-16 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,15 @@ RUN apt-get update \
     && apt-get install -y git cmake build-essential byacc libpcre3 libpcre3-dev grep lsb-release wget software-properties-common gnupg libcurl4-openssl-dev unzip lcov --no-install-recommends # skipcq: DOK-DL3018
 
 # Get LLVM
-ARG LLVM_VER=15
+ARG LLVM_VER=16
 RUN wget --no-verbose https://apt.llvm.org/llvm.sh
 RUN chmod +x ./llvm.sh \
   && ./llvm.sh ${LLVM_VER} \
   && apt-get -y install libclang-${LLVM_VER}-dev libclang-cpp${LLVM_VER}-dev --no-install-recommends \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && ln -s /usr/lib/x86_64-linux-gnu/libclang-16.so.16.0.6 /usr/lib/x86_64-linux-gnu/libclang-16.so.16
+
 
 # Add environment variables for build
 ENV PATH="$PATH:/usr/lib/llvm-${LLVM_VER}/bin"


### PR DESCRIPTION
This PR upgrades the LLVM version from fifteen to sixteen. It also create a missing symlink in llvm lib.

PS: When LLVM apt sort the issue of missing symlink we can remove the `ln -s` command.